### PR TITLE
Decouple release job from Flatpak build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -279,7 +279,7 @@ jobs:
   # Create GitHub Release (on tag push)
   # ══════════════════════════════════════════════
   release:
-    needs: [build-macos, build-windows, build-linux, build-flatpak]
+    needs: [build-macos, build-windows, build-linux]
     if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.create_release)
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- The GitHub release job currently requires `build-flatpak` to succeed via `needs:`, so a Flatpak-only issue (e.g. an EOL runtime branch needing a bump) can block cutting a release with otherwise-green AppImage/Windows/macOS builds.
- Removes `build-flatpak` from `release`'s `needs:` list. `build-flatpak` still runs on every push/dispatch as before, it just no longer gates the release.
- `softprops/action-gh-release`'s `fail_on_unmatched_files` defaults to `false`, so if the Flatpak artifact is missing (build skipped/failed), the release step simply omits it instead of failing.

## Test plan
- [x] Validated on a fork via `workflow_dispatch` (`create_release=false`): test, build-macos, build-windows, build-linux, and build-flatpak all passed — https://github.com/michaelpeeters/ChimpStackr/actions/runs/34019607899

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DE16ZvYLXe4rBmNignSqb1